### PR TITLE
Add startup popup, fullscreen mode and desktop shortcut

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8,6 +8,23 @@ sudo apt-get install -y python3 python3-pip python3-tk matchbox-keyboard mousepa
 # Install Python dependencies
 pip3 install --user pyudev requests
 
-echo "Installation complete."
+# Create desktop shortcut and icon
+ICON_PATH="/usr/share/pixmaps/MediaCenterPi.png"
+ICON_URL="https://access.st-braun.de/data/Media.png"
+sudo wget -q -O "$ICON_PATH" "$ICON_URL"
+
+USER_NAME="${SUDO_USER:-$USER}"
+DESKTOP_FILE="/home/$USER_NAME/Desktop/MediaCenterPi.desktop"
+cat <<EOF | sudo tee "$DESKTOP_FILE" >/dev/null
+[Desktop Entry]
+Type=Application
+Name=MediaCenterPi
+Exec=sudo python3 $(pwd)/mediacenter.py
+Icon=$ICON_PATH
+Terminal=false
+EOF
+sudo chmod +x "$DESKTOP_FILE"
+
+echo "Installation complete. Shortcut created at $DESKTOP_FILE"
 
 

--- a/mediacenter.py
+++ b/mediacenter.py
@@ -17,6 +17,7 @@ except ImportError:
     HAS_REQUESTS = False
 
 VERSION = "0.1.0"
+VERSION_DATE = "2025-06-19"
 UPDATE_URL = "https://raw.githubusercontent.com/studio-justin-braun/MediaCenterPi/main/mediacenter.py"
 
 try:
@@ -453,6 +454,7 @@ def open_config_editor():
 
 
 root = tk.Tk()
+root.attributes("-fullscreen", True)
 app = Toplevel1(root)
 
 # GUI-Elemente verbinden
@@ -479,6 +481,10 @@ def refresh_user_list():
             btn.configure(text="Not defined", state="disabled")
 
 def main():
+    messagebox.showinfo(
+        "MediaCenterPi",
+        f"Studio Justin Braun bedankt sich f\u00fcr die Nutzung von MediaCenter.\nVersion {VERSION} vom {VERSION_DATE}",
+    )
     refresh_user_list()
     update_sources()
     start_usb_monitor()


### PR DESCRIPTION
## Summary
- show version date constant
- start Tkinter GUI in fullscreen mode
- display welcome popup with version and date
- create a desktop shortcut with icon during install

## Testing
- `python -m py_compile mediacenter.py`

------
https://chatgpt.com/codex/tasks/task_e_68547817596083268425d52b5da589f9