### PR TITLE
Fix update routine when not in repo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# Repo Instructions for Codex
+
+* Run `python3 -m py_compile mediacenter.py` after modifying the Python file to ensure there are no syntax errors.
+* There are no automated tests. Manual execution can be done via `python3 mediacenter.py`, but this launches a GUI and may not work in headless mode.
+* Follow PEP8 style for Python code.


### PR DESCRIPTION
## Summary
- add repo instructions in `AGENTS.md`
- improve the update mechanism so `git pull` runs in the script directory
- fallback to manual download if the program isn't in a git repository

## Testing
- `python3 -m py_compile mediacenter.py`

------
https://chatgpt.com/codex/tasks/task_e_6854826dd42c832695b62055c175fc4a